### PR TITLE
Fix inconsistent package spelling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,14 @@
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.1.4</version>
     </parent>
-    <groupId>cz.littlestar.kubernates.testapp</groupId>
+    <groupId>cz.littlestar.kubernetes.testapp</groupId>
     <artifactId>springboot3exprerienceKubernetes</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>springboot3exprerienceKubernetes</name>
     <description>Demo project for Spring Boot</description>
     <properties>
         <java.version>17</java.version>
-        <module.image.name>milancecrdle/springbootsamplekubernates</module.image.name>
+        <module.image.name>milancecrdle/springbootsamplekubernetes</module.image.name>
     </properties>
     <dependencies>
         <dependency>

--- a/src/main/java/cz/littlestar/kubernetes/testapp/testapp/TestappApplication.java
+++ b/src/main/java/cz/littlestar/kubernetes/testapp/testapp/TestappApplication.java
@@ -1,4 +1,4 @@
-package cz.littlestar.kubernates.testapp.testapp;
+package cz.littlestar.kubernetes.testapp.testapp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/test/java/cz/littlestar/kubernetes/testapp/testapp/TestappApplicationTests.java
+++ b/src/test/java/cz/littlestar/kubernetes/testapp/testapp/TestappApplicationTests.java
@@ -1,4 +1,4 @@
-package cz.littlestar.kubernates.testapp.testapp;
+package cz.littlestar.kubernetes.testapp.testapp;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## Summary
- rename packages from `kubernates` to `kubernetes`
- update groupId and Docker image name in pom.xml

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685bf2b897cc8329aa2f460878005c44