### PR TITLE
Add MockMvc test for root endpoint

### DIFF
--- a/src/test/java/cz/littlestar/kubernates/testapp/testapp/TestappApplicationTests.java
+++ b/src/test/java/cz/littlestar/kubernates/testapp/testapp/TestappApplicationTests.java
@@ -1,13 +1,30 @@
 package cz.littlestar.kubernates.testapp.testapp;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 class TestappApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+       @Autowired
+       private MockMvc mockMvc;
+
+       @Test
+       void contextLoads() {
+       }
+
+       @Test
+       void homeEndpointReturnsHelloWorld() throws Exception {
+               mockMvc.perform(get("/"))
+                               .andExpect(status().isOk())
+                               .andExpect(content().string("Hello world"));
+       }
 
 }


### PR DESCRIPTION
## Summary
- use MockMvc in `TestappApplicationTests` to test the root endpoint

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf43837b4832995dbf26f01b7365c